### PR TITLE
Add in return when autoloader, PHP version, or class(es) aren't found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,6 @@ jobs:
           extensions: 'curl'
           extensions-cache-key: run-phpcs
           php-version: ${{ env.PHP_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           tools: 'composer, cs2pr, phpcs'
 
       - name: Run Phpcs
@@ -66,7 +65,6 @@ jobs:
           extensions: 'curl'
           extensions-cache-key: run-phpstan
           php-version: ${{ env.PHP_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           tools: 'composer, phpstan'
 
       - name: Run PHPStan
@@ -91,7 +89,6 @@ jobs:
           extensions: 'curl'
           extensions-cache-key: run-psalm
           php-version: ${{ env.PHP_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           tools: 'composer, psalm'
 
       - name: Run Psalm
@@ -129,7 +126,6 @@ jobs:
           extensions: 'curl, mysql, mysqli, zip'
           extensions-cache-key: run-phpunit
           php-version: ${{ env.PHP_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           tools: 'composer, phpunit'
 
       - name: Run PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
     "phpmd": [
       "bash ./vendor/thefrosty/wp-utilities/bin/phpmd.sh"
     ],
+    "phpstan": [
+      "bash ./vendor/thefrosty/wp-utilities/bin/phpstan.sh"
+    ],
     "psalm": [
       "bash ./vendor/thefrosty/wp-utilities/bin/psalm.sh"
     ],


### PR DESCRIPTION
Fixes #6.

# WP Block AI Scrapers Pull Request

## 😬 Risk:
[LOW]  

## 📖 Description:
* Add checks before loading.

## 🖥 Screenshot(s)
<img width="1139" alt="01 Notification_Center" src="https://github.com/thefrosty/wp-block-ai-scrapers/assets/367897/c59eb72b-41d1-45e4-8e03-137c70f020bf">
<img width="1149" alt="02 Plugins_‹_WP_—_WordPress" src="https://github.com/thefrosty/wp-block-ai-scrapers/assets/367897/4d7f4d0a-929f-45de-b0a9-ba04584b20d2">
<img width="1151" alt="03 Screen Shot 2024-03-14 at 9 27 24 AM" src="https://github.com/thefrosty/wp-block-ai-scrapers/assets/367897/732c20ef-4311-4344-b9c9-74c21c1dfbd3">
